### PR TITLE
Add authors name as link to social media if existing.

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -19,7 +19,19 @@ layout: default
 
         <div class="col-md-8">
             <h1>{{ page.title }}</h1>
-            <p>{{ page.date | date: "%b %-d, %Y" }}{% if page.author %} • {{ page.author }}{% endif %}{% if page.meta %} • {{ page.meta }}{% endif %}</p>
+            <p>{{ page.date | date: "%b %-d, %Y" }}
+                {% if page.author %} •
+                    {% assign author = site.data.authors[page.author] %}
+                    {% if author.twitter %}
+                        <a rel="author"
+                            href="https://twitter.com/{{ author.twitter }}"
+				            title="{{ author.name }}">{{page.author}}
+			            </a>
+                    {% else %}
+		                {{page.author}}
+	                {% endif %}
+		        {% endif %}
+		        {% if page.meta %} • {{ page.meta }}{% endif %}</p>
             <div  id="markdown-content-container">{{ content }}</div>
             <hr>
             <ul class="pager">

--- a/_posts/2019-03-20-micro-ROS_at_ERF2019.md
+++ b/_posts/2019-03-20-micro-ROS_at_ERF2019.md
@@ -18,10 +18,3 @@ The micro-ROS community demo was presented, making use of a Kobuki, one of the p
 ### Videos
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/Ca0wmFLi_oY" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-{% assign author = site.data.authors[page.author] %}
-<a rel="author"
-  href="https://twitter.com/{{ author.twitter }}"
-  title="{{ author.name }}">
-    {{ author.name }}
-</a>


### PR DESCRIPTION
A similar approach could be taken for GitHub accounts.