### PR TITLE
micro-ROS rcutils dependencies

### DIFF
--- a/_docs/concepts/client_library/rcutils_analysis/analysis.md
+++ b/_docs/concepts/client_library/rcutils_analysis/analysis.md
@@ -1,0 +1,138 @@
+# rcutils micro-ROS analysis
+
+- [rcutils micro-ROS analysis](#rcutils-micro-ros-analysis)
+  - [error_handling.h](#errorhandlingh)
+  - [security_directory.c](#securitydirectoryc)
+  - [allocator.c](#allocatorc)
+  - [filesystem.c](#filesystemc)
+
+*All dependencies include own header and implementation file.*
+
+*Test folders are excluded.*
+
+*security_filesystem appears both in rcl and rcutils due to the proposed location change.*
+
+## error_handling.h
+
+- Macro **RCUTILS_SAFE_FWRITE_TO_STDERR**. [Check here](https://github.com/micro-ROS/rcutils/commit/5bb92d91aae01feef046c05077997a686d35fe56#diff-1b06d4a1ccca0f0dff66d961923143a1L42)
+  - Problem: uses **fwrite()** 
+  - Dependecies:
+    - /uros/rcl/rcl/src/rcl/expand_topic_name.c
+    - /uros/rcl/rcl/src/rcl/logging_rosout.c
+    - /uros/rcl/rcl/src/rcl/logging.c
+    - /uros/rcl/rcl/src/rcl/context.c
+    - /uros/rcl/rcl_yaml_param_parser/src/parser.c
+    - /uros/rcutils/src/split.c
+    - /uros/rcutils/src/error_handling.c
+    - /uros/rcutils/src/allocator.c
+    - /uros/rcutils/src/logging.c
+    - /uros/rcutils/src/error_handling_helpers.h
+    - /uros/rcutils/include/rcutils/logging.h
+    - /uros/rcutils/include/rcutils/error_handling.h
+    - /ros2/rcl/rcl/src/rcl/expand_topic_name.c
+    - /ros2/rcl/rcl/src/rcl/logging_rosout.c
+    - /ros2/rcl/rcl/src/rcl/logging.c
+    - /ros2/rcl/rcl/src/rcl/context.c
+    - /ros2/rcl/rcl_yaml_param_parser/src/parser.c
+    - /ros2/rmw/rmw/include/rmw/error_handling.h
+
+- Macro **RCUTILS_SET_ERROR_MSG**. [Check here](https://github.com/micro-ROS/rcutils/commit/5bb92d91aae01feef046c05077997a686d35fe56#diff-1b06d4a1ccca0f0dff66d961923143a1L200)
+  - Problem: uses **__rcutils_copy_string()** 
+  - Dependecies:
+    - /uros/rcl/rcl/include/rcl/error_handling.h
+    - /uros/rcutils/src/security_directory.c
+    - /uros/rcutils/src/time_unix.c
+    - /uros/rcutils/src/split.c
+    - /uros/rcutils/src/error_handling.c
+    - /uros/rcutils/src/time.c
+    - /uros/rcutils/src/string_map.c
+    - /uros/rcutils/src/uint8_array.c
+    - /uros/rcutils/src/hash_map.c
+    - /uros/rcutils/src/char_array.c
+    - /uros/rcutils/src/logging.c
+    - /uros/rcutils/src/string_array.c
+    - /uros/rcutils/src/array_list.c
+    - /uros/rcutils/include/rcutils/types/array_list.h
+    - /uros/rcutils/include/rcutils/types/hash_map.h
+    - /uros/rcutils/include/rcutils/allocator.h
+    - /uros/rcutils/include/rcutils/error_handling.h
+    - /ros2/rcl/rcl/include/rcl/error_handling.h
+    - /ros2/rmw/rmw/include/rmw/error_handling.h
+
+- Macro **RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING**. [Check here](https://github.com/micro-ROS/rcutils/commit/5bb92d91aae01feef046c05077997a686d35fe56#diff-1b06d4a1ccca0f0dff66d961923143a1L212)
+  - Problem: uses **rcutils_snprintf()** 
+  - Dependecies:
+    - /uros/rcl/rcl/include/rcl/error_handling.h
+    - /uros/rcutils/src/security_directory.c
+    - /uros/rcutils/src/string_map.c
+    - /uros/rcutils/src/logging.c
+    - /uros/rcutils/include/rcutils/error_handling.h
+    - /ros2/rcl/rcl/include/rcl/error_handling.h
+    - /ros2/rmw/rmw/include/rmw/error_handling.h
+
+## security_directory.c
+
+- Function **get_best_matching_directory()**. [Check here](https://github.com/micro-ROS/rcutils/commit/9b6c4d6b0e954d4a84a1ae41aa7657aa876ecf23#diff-1ca0173d6a68ba1bdcd9ff908b769911L87)
+  - Problem: uses **tinydir** library
+  - Dependecies:
+    - /uros/rcutils/src/security_directory.c
+    - /ros2/rcl/rcl/src/rcl/security_directory.c
+
+- Function **prefix_match_lookup()**. [Check here](https://github.com/micro-ROS/rcutils/commit/9b6c4d6b0e954d4a84a1ae41aa7657aa876ecf23#diff-1ca0173d6a68ba1bdcd9ff908b769911L151)
+  - Problem: uses **_TINYDIR_FILENAME_MAX** macro from **tinydir** library
+  - Dependencies:
+    - /uros/rcutils/src/security_directory.c
+    - /ros2/rcl/rcl/src/rcl/security_directory.c
+
+## allocator.c
+
+- Function **rcutils_get_default_allocator()**. [Check here](https://github.com/micro-ROS/rcutils/commit/1a7fde263eae6ddffbabfd6ac22b62b93afc153f#diff-e2e6ccf38de409700323df9674d18304L72)
+  - Problem: uses static allocated **default_allocator** which uses malloc/free
+  - Dependecies:
+    - /uros/rcl/rcl/include/rcl/allocator.h
+    - /uros/rcl/rcl/include/rcl/expand_topic_name.h
+    - /uros/rcutils/src/allocator.c
+    - /uros/rcutils/src/logging.c
+    - /uros/rcutils/include/rcutils/types/string_map.h
+    - /uros/rcutils/include/rcutils/types/array_list.h
+    - /uros/rcutils/include/rcutils/types/string_array.h
+    - /uros/rcutils/include/rcutils/types/hash_map.h
+    - /uros/rcutils/include/rcutils/allocator.h
+    - /ros2/rmw_implementation/rmw_implementation/src/functions.cpp
+    - /ros2/rcl/rcl/include/rcl/allocator.h
+    - /ros2/rcl/rcl/include/rcl/expand_topic_name.h
+    - /ros2/rmw/rmw/src/allocators.c
+
+## filesystem.c
+
+- Functions **rcutils_get_cwd()**, **rcutils_is_directory()**, **rcutils_is_file()**, **rcutils_exists()**, **rcutils_is_readable()**, **rcutils_is_writable()** and **rcutils_is_readable_and_writable()**. [Check here](https://github.com/micro-ROS/rcutils/commit/5a94c101ae6cec65f0c4caae0fa9e2e5a0b2d39a)
+  - Problem: uses **#include <sys/stat.h>** which is filesystem related
+  - Dependecies **rcutils_get_cwd()**:
+    - /uros/rcutils/src/filesystem.c
+    - /uros/rcutils/include/rcutils/filesystem.h
+  - Dependecies **rcutils_is_directory()**:
+    - /uros/rcutils/src/security_directory.c
+    - /uros/rcutils/src/filesystem.c
+    - /uros/rcutils/include/rcutils/filesystem.h
+    - /ros2/rcl/rcl/src/rcl/security_directory.c
+  - Dependecies **rcutils_is_file()**:
+    - /uros/rcutils/src/filesystem.c
+    - /uros/rcutils/include/rcutils/filesystem.h
+  - Dependencies **rcutils_exists()**:
+    - /uros/rcutils/src/filesystem.c
+    - /uros/rcutils/include/rcutils/filesystem.h
+  - Dependencies **rcutils_is_readable()**:
+    - /uros/rcutils/src/filesystem.c
+    - /uros/rcutils/include/rcutils/filesystem.h
+  - Dependencies **rcutils_is_writable()**:
+    - /uros/rcutils/src/filesystem.c
+    - /uros/rcutils/include/rcutils/filesystem.h
+  - Dependencies **rcutils_is_readable_and_writable()**:
+    - /uros/rcutils/src/filesystem.c
+    - /uros/rcutils/include/rcutils/filesystem.h
+
+Dependencies searching command:
+
+```bash
+grep -Hnr "[Command here]" ./uros ./ros2 | sed -E "s/(.+)\:([0-9]+)\:(.+)/   - \1/" | uniq
+```

--- a/_docs/concepts/client_library/rcutils_analysis/analysis.md
+++ b/_docs/concepts/client_library/rcutils_analysis/analysis.md
@@ -1,138 +1,139 @@
-# rcutils micro-ROS analysis
+## Proposed changes
 
-- [rcutils micro-ROS analysis](#rcutils-micro-ros-analysis)
-  - [error_handling.h](#errorhandlingh)
-  - [security_directory.c](#securitydirectoryc)
-  - [allocator.c](#allocatorc)
-  - [filesystem.c](#filesystemc)
+The main issues found when porting rcutils package to embedded systems with RTOS during micro-ROS development were:
+ - the lack of filesystem
+ - dynamic memory allocations out of the RTOS control (usually with standar library implementations of `malloc` and `free`)
+ - the POSIX API dependency
 
-*All dependencies include own header and implementation file.*
+This document addresses the first two items.
+
+In order to avoid the **filesystem** dependency without modifiying high level layers (such as `rcl` or `rmw`), it is proposed to use a combination between the available `rcl_logging_noop` package and a modified version of the filesystem dependecies in `rcutils`. This approach is enabled using `RCUTILS_NO_FILESYSTEM` flag in compilation time. 
+
+**Dynamic memory allocation** must be bounded to ROS2 custom allocators. `rcl` and `rmw` layers usually rely on `rcutils_get_default_allocator` function in order to obtain allocators, so a setter function is proposed.
+This way, using `rcutils_set_default_allocator` function is possible to modify the defaults easing the use of custom memory management in embedded systems.
+
+Dynamic memory allocation is also found when dealing with error handling in `rcutils`. By using `RCUTILS_AVOID_DYNAMIC_ALLOCATION` some string related `memmove` functions along the error handling are avoided.
+
+## Dependencies in `rcl`, `rcutils` and `rmw`
 
 *Test folders are excluded.*
 
-*security_filesystem appears both in rcl and rcutils due to the proposed location change.*
+### error_handling.h
 
-## error_handling.h
+- Macro **RCUTILS_SAFE_FWRITE_TO_STDERR** in `rcutils` error_handling.h:
+   [Check here](https://github.com/micro-ROS/rcutils/commit/bcaa00a6ed12fc62d05dc5e44521a1648fd2d07f#diff-1b06d4a1ccca0f0dff66d961923143a1L42)
+  - Problem: use `fwrite` to print to stderr and relies on a filesytem
+  - Appears in:
+    - rcl/rcl/src/rcl/expand_topic_name.c
+    - rcl/rcl/src/rcl/logging_rosout.c
+    - rcl/rcl/src/rcl/logging.c
+    - rcl/rcl/src/rcl/context.c
+    - rcl/rcl_yaml_param_parser/src/parser.c
+    - rcutils/src/split.c
+    - rcutils/src/error_handling.c
+    - rcutils/src/allocator.c
+    - rcutils/src/logging.c
+    - rcutils/src/error_handling_helpers.h
+    - rcutils/include/rcutils/logging.h
+    - rcutils/include/rcutils/error_handling.h
+    - rcl/rcl/src/rcl/expand_topic_name.c
+    - rcl/rcl/src/rcl/logging_rosout.c
+    - rcl/rcl/src/rcl/logging.c
+    - rcl/rcl/src/rcl/context.c
+    - rcl/rcl_yaml_param_parser/src/parser.c
+    - rmw/rmw/include/rmw/error_handling.h
 
-- Macro **RCUTILS_SAFE_FWRITE_TO_STDERR**. [Check here](https://github.com/micro-ROS/rcutils/commit/5bb92d91aae01feef046c05077997a686d35fe56#diff-1b06d4a1ccca0f0dff66d961923143a1L42)
-  - Problem: uses **fwrite()** 
+- Macro **RCUTILS_SET_ERROR_MSG** in `rcutils` error_handling.h: [Check here](https://github.com/micro-ROS/rcutils/commit/bcaa00a6ed12fc62d05dc5e44521a1648fd2d07f#diff-1b06d4a1ccca0f0dff66d961923143a1R202)
+  - Problem: use inconditionally `memmove` inside `__rcutils_copy_string()` inside `rcutils_set_error_state`. It implies dynamic memory allocation.
   - Dependecies:
-    - /uros/rcl/rcl/src/rcl/expand_topic_name.c
-    - /uros/rcl/rcl/src/rcl/logging_rosout.c
-    - /uros/rcl/rcl/src/rcl/logging.c
-    - /uros/rcl/rcl/src/rcl/context.c
-    - /uros/rcl/rcl_yaml_param_parser/src/parser.c
-    - /uros/rcutils/src/split.c
-    - /uros/rcutils/src/error_handling.c
-    - /uros/rcutils/src/allocator.c
-    - /uros/rcutils/src/logging.c
-    - /uros/rcutils/src/error_handling_helpers.h
-    - /uros/rcutils/include/rcutils/logging.h
-    - /uros/rcutils/include/rcutils/error_handling.h
-    - /ros2/rcl/rcl/src/rcl/expand_topic_name.c
-    - /ros2/rcl/rcl/src/rcl/logging_rosout.c
-    - /ros2/rcl/rcl/src/rcl/logging.c
-    - /ros2/rcl/rcl/src/rcl/context.c
-    - /ros2/rcl/rcl_yaml_param_parser/src/parser.c
-    - /ros2/rmw/rmw/include/rmw/error_handling.h
+    - rcl/rcl/include/rcl/error_handling.h
+    - rcutils/src/security_directory.c
+    - rcutils/src/time_unix.c
+    - rcutils/src/split.c
+    - rcutils/src/error_handling.c
+    - rcutils/src/time.c
+    - rcutils/src/string_map.c
+    - rcutils/src/uint8_array.c
+    - rcutils/src/hash_map.c
+    - rcutils/src/char_array.c
+    - rcutils/src/logging.c
+    - rcutils/src/string_array.c
+    - rcutils/src/array_list.c
+    - rcutils/include/rcutils/types/array_list.h
+    - rcutils/include/rcutils/types/hash_map.h
+    - rcutils/include/rcutils/allocator.h
+    - rcutils/include/rcutils/error_handling.h
+    - rcl/rcl/include/rcl/error_handling.h
+    - rmw/rmw/include/rmw/error_handling.h
 
-- Macro **RCUTILS_SET_ERROR_MSG**. [Check here](https://github.com/micro-ROS/rcutils/commit/5bb92d91aae01feef046c05077997a686d35fe56#diff-1b06d4a1ccca0f0dff66d961923143a1L200)
-  - Problem: uses **__rcutils_copy_string()** 
+- Macro **RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING** in `rcutils` error_handling.h:. [Check here](https://github.com/micro-ROS/rcutils/commit/bcaa00a6ed12fc62d05dc5e44521a1648fd2d07f#diff-1b06d4a1ccca0f0dff66d961923143a1R218)
+  - Problem: use `RCUTILS_SET_ERROR_MSG`, see above.
   - Dependecies:
-    - /uros/rcl/rcl/include/rcl/error_handling.h
-    - /uros/rcutils/src/security_directory.c
-    - /uros/rcutils/src/time_unix.c
-    - /uros/rcutils/src/split.c
-    - /uros/rcutils/src/error_handling.c
-    - /uros/rcutils/src/time.c
-    - /uros/rcutils/src/string_map.c
-    - /uros/rcutils/src/uint8_array.c
-    - /uros/rcutils/src/hash_map.c
-    - /uros/rcutils/src/char_array.c
-    - /uros/rcutils/src/logging.c
-    - /uros/rcutils/src/string_array.c
-    - /uros/rcutils/src/array_list.c
-    - /uros/rcutils/include/rcutils/types/array_list.h
-    - /uros/rcutils/include/rcutils/types/hash_map.h
-    - /uros/rcutils/include/rcutils/allocator.h
-    - /uros/rcutils/include/rcutils/error_handling.h
-    - /ros2/rcl/rcl/include/rcl/error_handling.h
-    - /ros2/rmw/rmw/include/rmw/error_handling.h
+    - rcl/rcl/include/rcl/error_handling.h
+    - rcutils/src/security_directory.c
+    - rcutils/src/string_map.c
+    - rcutils/src/logging.c
+    - rcutils/include/rcutils/error_handling.h
+    - rcl/rcl/include/rcl/error_handling.h
+    - rmw/rmw/include/rmw/error_handling.h
 
-- Macro **RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING**. [Check here](https://github.com/micro-ROS/rcutils/commit/5bb92d91aae01feef046c05077997a686d35fe56#diff-1b06d4a1ccca0f0dff66d961923143a1L212)
-  - Problem: uses **rcutils_snprintf()** 
+### security_directory.c (moved from `rcl` to `rcutils`)
+
+- Function **get_best_matching_directory** in `rcutils` security_directory.c [Check here](https://github.com/micro-ROS/rcutils/commit/9804287c3489ce9c88b714832abf54f9a7b7198d#diff-1ca0173d6a68ba1bdcd9ff908b769911R91)
+  - Problem: use **tinydir** library which relies on filesytem
   - Dependecies:
-    - /uros/rcl/rcl/include/rcl/error_handling.h
-    - /uros/rcutils/src/security_directory.c
-    - /uros/rcutils/src/string_map.c
-    - /uros/rcutils/src/logging.c
-    - /uros/rcutils/include/rcutils/error_handling.h
-    - /ros2/rcl/rcl/include/rcl/error_handling.h
-    - /ros2/rmw/rmw/include/rmw/error_handling.h
+    - rcutils/src/security_directory.c
+    - rcl/rcl/src/rcl/security_directory.c
 
-## security_directory.c
-
-- Function **get_best_matching_directory()**. [Check here](https://github.com/micro-ROS/rcutils/commit/9b6c4d6b0e954d4a84a1ae41aa7657aa876ecf23#diff-1ca0173d6a68ba1bdcd9ff908b769911L87)
-  - Problem: uses **tinydir** library
-  - Dependecies:
-    - /uros/rcutils/src/security_directory.c
-    - /ros2/rcl/rcl/src/rcl/security_directory.c
-
-- Function **prefix_match_lookup()**. [Check here](https://github.com/micro-ROS/rcutils/commit/9b6c4d6b0e954d4a84a1ae41aa7657aa876ecf23#diff-1ca0173d6a68ba1bdcd9ff908b769911L151)
-  - Problem: uses **_TINYDIR_FILENAME_MAX** macro from **tinydir** library
+- Function **prefix_match_lookup**. [Check here](https://github.com/micro-ROS/rcutils/commit/9804287c3489ce9c88b714832abf54f9a7b7198d#diff-1ca0173d6a68ba1bdcd9ff908b769911L151)
+  - Problem: use **tinydir** library which relies on filesytem
   - Dependencies:
-    - /uros/rcutils/src/security_directory.c
-    - /ros2/rcl/rcl/src/rcl/security_directory.c
+    - rcutils/src/security_directory.c
+    - rcl/rcl/src/rcl/security_directory.c
 
-## allocator.c
+### allocator.c
 
-- Function **rcutils_get_default_allocator()**. [Check here](https://github.com/micro-ROS/rcutils/commit/1a7fde263eae6ddffbabfd6ac22b62b93afc153f#diff-e2e6ccf38de409700323df9674d18304L72)
-  - Problem: uses static allocated **default_allocator** which uses malloc/free
+- Function **rcutils_get_default_allocator**. [Check here](https://github.com/micro-ROS/rcutils/commit/3abb1eb2c9b206054101293997c0d4e541b1c657)
+  - Problem: use static allocated **default_allocator** which uses malloc/free. **rcutils_set_default_allocator** is proposed.
   - Dependecies:
-    - /uros/rcl/rcl/include/rcl/allocator.h
-    - /uros/rcl/rcl/include/rcl/expand_topic_name.h
-    - /uros/rcutils/src/allocator.c
-    - /uros/rcutils/src/logging.c
-    - /uros/rcutils/include/rcutils/types/string_map.h
-    - /uros/rcutils/include/rcutils/types/array_list.h
-    - /uros/rcutils/include/rcutils/types/string_array.h
-    - /uros/rcutils/include/rcutils/types/hash_map.h
-    - /uros/rcutils/include/rcutils/allocator.h
-    - /ros2/rmw_implementation/rmw_implementation/src/functions.cpp
-    - /ros2/rcl/rcl/include/rcl/allocator.h
-    - /ros2/rcl/rcl/include/rcl/expand_topic_name.h
-    - /ros2/rmw/rmw/src/allocators.c
+    - rcl/rcl/include/rcl/allocator.h
+    - rcl/rcl/include/rcl/expand_topic_name.h
+    - rcutils/src/allocator.c
+    - rcutils/src/logging.c
+    - rcutils/include/rcutils/types/string_map.h
+    - rcutils/include/rcutils/types/array_list.h
+    - rcutils/include/rcutils/types/string_array.h
+    - rcutils/include/rcutils/types/hash_map.h
+    - rcutils/include/rcutils/allocator.h
+    - rmw_implementation/rmw_implementation/src/functions.cpp
+    - rcl/rcl/include/rcl/allocator.h
+    - rcl/rcl/include/rcl/expand_topic_name.h
+    - rmw/rmw/src/allocators.c
 
-## filesystem.c
+### filesystem.c
 
-- Functions **rcutils_get_cwd()**, **rcutils_is_directory()**, **rcutils_is_file()**, **rcutils_exists()**, **rcutils_is_readable()**, **rcutils_is_writable()** and **rcutils_is_readable_and_writable()**. [Check here](https://github.com/micro-ROS/rcutils/commit/5a94c101ae6cec65f0c4caae0fa9e2e5a0b2d39a)
-  - Problem: uses **#include <sys/stat.h>** which is filesystem related
+- Functions **rcutils_get_cwd**, **rcutils_is_directory**, **rcutils_is_file**, **rcutils_exists**, **rcutils_is_readable**, **rcutils_is_writable** and **rcutils_is_readable_and_writable**. [Check here](https://github.com/micro-ROS/rcutils/commit/9804287c3489ce9c88b714832abf54f9a7b7198d)
+  - Problem: rely on filesystem
   - Dependecies **rcutils_get_cwd()**:
-    - /uros/rcutils/src/filesystem.c
-    - /uros/rcutils/include/rcutils/filesystem.h
+    - rcutils/src/filesystem.c
+    - rcutils/include/rcutils/filesystem.h
   - Dependecies **rcutils_is_directory()**:
-    - /uros/rcutils/src/security_directory.c
-    - /uros/rcutils/src/filesystem.c
-    - /uros/rcutils/include/rcutils/filesystem.h
-    - /ros2/rcl/rcl/src/rcl/security_directory.c
+    - rcutils/src/security_directory.c
+    - rcutils/src/filesystem.c
+    - rcutils/include/rcutils/filesystem.h
+    - rcl/rcl/src/rcl/security_directory.c
   - Dependecies **rcutils_is_file()**:
-    - /uros/rcutils/src/filesystem.c
-    - /uros/rcutils/include/rcutils/filesystem.h
+    - rcutils/src/filesystem.c
+    - rcutils/include/rcutils/filesystem.h
   - Dependencies **rcutils_exists()**:
-    - /uros/rcutils/src/filesystem.c
-    - /uros/rcutils/include/rcutils/filesystem.h
+    - rcutils/src/filesystem.c
+    - rcutils/include/rcutils/filesystem.h
   - Dependencies **rcutils_is_readable()**:
-    - /uros/rcutils/src/filesystem.c
-    - /uros/rcutils/include/rcutils/filesystem.h
+    - rcutils/src/filesystem.c
+    - rcutils/include/rcutils/filesystem.h
   - Dependencies **rcutils_is_writable()**:
-    - /uros/rcutils/src/filesystem.c
-    - /uros/rcutils/include/rcutils/filesystem.h
+    - rcutils/src/filesystem.c
+    - rcutils/include/rcutils/filesystem.h
   - Dependencies **rcutils_is_readable_and_writable()**:
-    - /uros/rcutils/src/filesystem.c
-    - /uros/rcutils/include/rcutils/filesystem.h
-
-Dependencies searching command:
-
-```bash
-grep -Hnr "[Command here]" ./uros ./ros2 | sed -E "s/(.+)\:([0-9]+)\:(.+)/   - \1/" | uniq
-```
+    - rcutils/src/filesystem.c
+    - rcutils/include/rcutils/filesystem.h


### PR DESCRIPTION
This PR add an first approach to rcutils problematic dependecies in micro-ROS: dynamic memory allocation and filesystem.