### PR TITLE
Demos README remove header

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,31 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+# To fully customize the contents of this image, use the following Dockerfile instead:
+# https://github.com/microsoft/vscode-dev-containers/tree/v0.106.0/containers/ubuntu-18.04-git/.devcontainer/Dockerfile
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-ubuntu-18.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+   && apt-get -y install --no-install-recommends build-essential ruby ruby-dev locales zlib1g-dev \
+   && gem install bundler \
+   #
+   # Clean up
+   && apt-get autoremove -y \
+   && apt-get clean -y \
+   && rm -rf /var/lib/apt/lists/*
+
+RUN echo "en_US UTF-8" > /etc/locale.gen \
+    && locale-gen en_US.UTF-8
+
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+ENV DEBIAN_FRONTEND=dialog
+
+# TEST COMMANDS:
+# bundle install
+# bundle exec jekyll serve
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.106.0/containers/ubuntu-18.04-git
+{
+	"name": "Ubuntu 18.04 & Git",
+	"dockerFile": "Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": []
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-in-docker.
+	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+	"runArgs": [ "--net=host"],
+
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/_docs/tutorials/demos/crazyflie_demo/index.md
+++ b/_docs/tutorials/demos/crazyflie_demo/index.md
@@ -1,5 +1,6 @@
 ---
 title: Crazyflie Demo
+layout: docs_noheader
 permalink: /docs/tutorials/demos/crazyflie_demo/
 redirect_from:
   - /crazyflie_demo/

--- a/_docs/tutorials/demos/tof_demo/index.md
+++ b/_docs/tutorials/demos/tof_demo/index.md
@@ -1,5 +1,6 @@
 ---
 title: Time of Flight Sensor Demo
+layout: docs_noheader
 permalink: /docs/tutorials/demos/tof_demo/
 ---
 

--- a/_layouts/docs_noheader.html
+++ b/_layouts/docs_noheader.html
@@ -1,0 +1,26 @@
+---
+layout: default
+---
+
+<div class="container">
+    <div class="row">
+        <div class="col-md-4">
+          {% include docs_nav.html %}
+        </div>
+
+        <div class="col-md-8">
+            <div id="markdown-content-container">{{ content }}</div>
+            <div style="clear:both;">
+              <p class="text-center">
+                <br />
+                <a target="_blank" href="{{site.git_edit_address}}/{{ page.path }}" class="btn btn-default githubEditButton" role="button">
+                  <i class="fa fa-pencil fa-lg"></i> Improve this page
+                </a>
+              </p>
+            </div>
+            <hr>
+            {% include section_nav.html %}
+        </div>
+
+    </div>
+</div>


### PR DESCRIPTION
This PR add a VSC devcontainer for local testing purposes and fixes the double header when including external README.md files