### PR TITLE
Small rclc lifecycle tutorial

### DIFF
--- a/_docs/tutorials/core/programming_rcl_rclc/index.md
+++ b/_docs/tutorials/core/programming_rcl_rclc/index.md
@@ -11,12 +11,11 @@ In this tutorial, you'll learn the basics of the micro-ROS C API. The major conc
 * [Timers](#timers)
 * [Rclc Executor](#rclc_executor)
 
-
 ## <a name="node"/>Creating a Node
 
 To simplify the creation of a node with rcl, rclc provides two functions `rclc_support_init(..)` and `rclc_node_init_default(..)` in [rclc/init.h](https://github.com/micro-ROS/rclc/blob/master/rclc/include/rclc/init.h) and [rclc/node.h](https://github.com/micro-ROS/rclc/blob/master/rclc/include/rclc/node.h), respectively. The first lines of the main function of a micro-ROS programm are:
 
-```c
+```C
 rcl_allocator_t allocator = rcl_get_default_allocator();
 rclc_support_t support;
 rcl_ret_t rc;
@@ -41,7 +40,7 @@ Publishers and subscribers are most easily created with the rclc package.
 
 Creating a publisher by `rclc_publisher_init_default(..)` from [rclc/publisher.h](https://github.com/micro-ROS/rclc/blob/master/rclc/include/rclc/publisher.h):
 
-```c
+```C
 rcl_publisher_t my_pub;
 std_msgs__msg__String my_msg;
 const char * my_topic = "topic_0";
@@ -56,7 +55,7 @@ if (RCL_RET_OK != rc) {
 
 Initializing a message:
 
-```c
+```C
 std_msgs__msg__String__init(&pub_msg);
 const unsigned int PUB_MSG_SIZE = 20;
 char pub_string[PUB_MSG_SIZE];
@@ -66,7 +65,7 @@ rosidl_generator_c__String__assignn(&pub_msg, pub_string, PUB_MSG_SIZE);
 
 Creating a subscription by `rclc_subscription_init_default(..)` from [rclc/subscription.h](https://github.com/micro-ROS/rclc/blob/master/rclc/include/rclc/subscription.h):
 
-```c
+```C
 rcl_subscription_t my_sub = rcl_get_zero_initialized_subscription();
 rc = rclc_subscription_init_default(&my_sub, &my_node, &my_type_support, &my_topic_name);
 if (rc != RCL_RET_OK) {
@@ -85,7 +84,7 @@ Note: Services are not supported in rclc package yet. Therefore the configuratio
 
 Starting from a code where RCL is initialized and a micro-ROS node is created, these steps are required in order to generate a service server:
 
-```c
+```C
 // Creating service server and options
 rcl_service_options_t service_options = rcl_service_get_default_options();
 rcl_service_t server = rcl_get_zero_initialized_service();
@@ -101,7 +100,7 @@ rcl_wait_set_init(&wait_set, 0, 0, 0, 0, 1, 0, &context, rcl_get_default_allocat
 
 On the other hand the service client initialization looks like that:
 
-```c
+```C
 // Creating service client and options
 rcl_client_options_t client_options = rcl_client_get_default_options();
 rcl_client_t client = rcl_get_zero_initialized_client();
@@ -116,7 +115,7 @@ rcl_wait_set_init(&wait_set, 0, 0, 0, 1, 0, 0, &context, rcl_get_default_allocat
 
 First of all, by looking at `AddTwoInts.srv` type definition it is possible to determine request and reply elements of the service. Service client will make a request with two integers and service server should send its sum as a response.
 
-```
+```C
 int64 a
 int64 b
 ---
@@ -125,7 +124,7 @@ int64 sum
 
 Once service client and server are configured, service client can perform a request and wait for reply:
 
-```c
+```C
 // Creating a service request
 int64_t seq;
 example_interfaces__srv__AddTwoInts_Request req;
@@ -147,7 +146,7 @@ do {
     rcl_wait(&wait_set, RCL_MS_TO_NS(1));
 
     // If wait set client element is not null, response is ready
-    if (wait_set.clients[index]) {   
+    if (wait_set.clients[index]) {
         rmw_request_id_t req_id;
 
         // Create a service response struct
@@ -166,7 +165,7 @@ do {
 
 On service server side, the ROS 2 node should be waiting for service requests and generate service replies:
 
-```c
+```C
 while(1){
     rcl_wait_set_clear(&wait_set);
 
@@ -176,7 +175,7 @@ while(1){
     rcl_wait(&wait_set, RCL_MS_TO_NS(1));
 
     // If wait set service element is not null, request is ready
-    if (wait_set.services[index]) {   
+    if (wait_set.services[index]) {
         rmw_request_id_t req_id;
 
         // Create a service request struct
@@ -195,12 +194,12 @@ while(1){
 }
 ```
 
-
-
 ## <a name="timers"/>Timers
+
 A timer can be created with the rclc-package with the function
 `rclc_timer_init_default(..)` in [rclc/timer.h](https://github.com/micro-ROS/rclc/blob/master/rclc/include/rclc/timer.h):
-```c
+
+```C
 // create a timer, which will call the publisher with period=`timer_timeout` ms in the 'my_timer_callback'
 rcl_timer_t my_timer = rcl_get_zero_initialized_timer();
 const unsigned int timer_timeout = 1000;
@@ -214,21 +213,23 @@ if (rc != RCL_RET_OK) {
 ```
 
 ## <a name="rclc_executor"/>rclc Executor
+
 The rclc Executor provides a C API to manage the execution of subscription and timer callbacks, similar to the [rclcpp Executor](https://github.com/ros2/rclcpp/blob/master/rclcpp/include/rclcpp/executor.hpp) for C++. The rclc Executor is optimized for resource-constrained devices and provides additional features that allow the manual implementation of deterministic schedules with bounded end-to-end latencies.
 
 In this tutorial we provide two examples:
-- Example 1: Hello-World example consisting of one executor and one publisher, timer and subscription.
-- Example 2: Triggered execution example, demonstrating the capability of synchronizing the execution of callbacks based on the availability of new messages
 
+* Example 1: Hello-World example consisting of one executor and one publisher, timer and subscription.
+* Example 2: Triggered execution example, demonstrating the capability of synchronizing the execution of callbacks based on the availability of new messages
 
 Further examples for using the rclc Executor in mobile robotics scenarios and real-time embedded applications can be found in the [rclc](https://github.com/micro-ROS/rclc/tree/master/rclc) repository.
 
 ### Example 1: 'Hello World'
+
 To start with, we provide a very simple example for an rclc Executor with one timer and one subscription, so to say, a 'Hello world' example. It consists of a publisher, sending a 'hello world' message to a subscriber, which then prints out the received message on the console.
 
 First, you include some header files, in particular the [rclc/rclc.h](https://github.com/micro-ROS/rclc/blob/master/rclc/include/rclc/rclc.h) and [rclc/executor.h](https://github.com/micro-ROS/rclc/blob/master/rclc/include/rclc/executor.h).
 
-```c
+```C
 #include <stdio.h>
 #include <std_msgs/msg/string.h>
 #include <rclc/rclc.h>
@@ -236,11 +237,13 @@ First, you include some header files, in particular the [rclc/rclc.h](https://gi
 ```
 
 We define a publisher and two strings, which will be used later.
-```c
+
+```C
 rcl_publisher_t my_pub;
 std_msgs__msg__String pub_msg;
 std_msgs__msg__String sub_msg;
 ```
+
 The subscription callback casts the message parameter `msgin` to an equivalent type of `std_msgs::msg::String` in C and prints out the received message.
 
 ```C
@@ -254,6 +257,7 @@ void my_subscriber_callback(const void * msgin)
   }
 }
 ```
+
 The timer callback publishes the message `pub_msg` with the publisher `my_pub`, which is initialized later in `main()`.
 
 ```C
@@ -273,7 +277,9 @@ void my_timer_callback(rcl_timer_t * timer, int64_t last_call_time)
   }
 }
 ```
+
 After defining the callback functions, we present now the `main()` function. First, some initialization is necessary to create later rcl objects. That is an `allocator` for dynamic memory allocation, and a `support` object, which contains some rcl-objects simplifying the initialization of an rcl-node, an rcl-subscription, an rcl-timer and an rclc-executor.
+
 ```C
 int main(int argc, const char * argv[])
 {
@@ -290,6 +296,7 @@ int main(int argc, const char * argv[])
 ```
 
 Next, you define a ROS 2 node `my_node` with `rcl_get_zero_initialized_node()` and initialize it with `rclc_executor_init_default()`:
+
 ```C
   // create rcl_node
   rcl_node_t my_node = rcl_get_zero_initialized_node();
@@ -299,7 +306,9 @@ Next, you define a ROS 2 node `my_node` with `rcl_get_zero_initialized_node()` a
     return -1;
   }
 ```
+
 You can create a publisher to publish topic 'topic_0' with type std_msg::msg::String with the following code:
+
 ```C
 const char * topic_name = "topic_0";
 const rosidl_message_type_support_t * my_type_support =
@@ -311,9 +320,11 @@ if (RCL_RET_OK != rc) {
   return -1;
 }
 ```
+
 Note, that variable `my_pub` was defined globally, so it can be used by the timer callback.
 
 You can create a timer `my_timer` with a period of one second, which executes the callback `my_timer_callback` like this:
+
 ```C
   rcl_timer_t my_timer = rcl_get_zero_initialized_timer();
   const unsigned int timer_timeout = 1000; // in ms
@@ -325,7 +336,9 @@ You can create a timer `my_timer` with a period of one second, which executes th
     printf("Created timer with timeout %d ms.\n", timer_timeout);
   }
 ```
+
 The string `Hello World!` can be assigned directly to the message of the publisher `pub_msg.data`. First the publisher message is initialized with `std_msgs__msg__String__init`. Then you need to allocate memory for `pub_msg.data.data`, set the maximum capacity `pub_msg.data.capacity` and set the length of the message `pub_msg.data.size` accordingly. You can assign the content of the message with `snprintf` of `pub_msg.data.data`.
+
 ```C
   // assign message to publisher
   std_msgs__msg__String__init(&pub_msg);
@@ -337,6 +350,7 @@ The string `Hello World!` can be assigned directly to the message of the publish
 ```
 
 A subscription `my_sub`can be defined like this:
+
 ```C
   rcl_subscription_t my_sub = rcl_get_zero_initialized_subscription();
   rc = rclc_subscription_init_default(&my_sub, &my_node, my_type_support, topic_name);
@@ -347,16 +361,20 @@ A subscription `my_sub`can be defined like this:
     printf("Created subscriber %s:\n", topic_name);
   }
 ```
+
 The global message for this subscription `sub_msg` needs to be initialized with:
+
 ```C
   std_msgs__msg__String__init(&sub_msg);
 ```
 
 Now, all preliminary steps are done, and you can define and initialized the rclc executor with:
-```c
+
+```C
   rclc_executor_t executor;
   executor = rclc_executor_get_zero_initialized_executor();
 ```
+
 In the next step, executor is initialized with the ROS 2 `context`, the number of communication objects `num_handles` and an `allocator`. The number of communication objects defines the total number of timers and subscriptions, the executor shall manage. In this example, the executor will be setup with one timer and one subscription.
 
 ```C
@@ -373,27 +391,32 @@ if (rc != RCL_RET_OK) {
   printf("Error in rclc_executor_add_subscription. \n");
 }
 ```
+
 The option `ON_NEW_DATA` selects the execution semantics of the spin-method. In this example, the callback of the subscription `my_sub`is only called if new data is available.
 
 Note: Another execution semantics is `ALWAYS`, which means, that the subscription callback is always executed when the spin-method of the executor is called. This option might be useful in cases in which the callback shall be executed at a fixed rate irrespective of new data is available or not. If you choose this option, then the callback will be executed with message argument `NULL` if no new data is available. Therefore you need to make sure, that your callback also accepts `NULL` as message argument.
 
-
 Likewise, you can add the timer `my_timer` with the function `rclc_c_executor_add_timer`:
-```c
+
+```C
 rclc_executor_add_timer(&executor, &my_timer);
 if (rc != RCL_RET_OK) {
   printf("Error in rclc_executor_add_timer.\n");
 }
 ```
-A key feature of the rclc Executor is that the order of these `rclc-executor-add-* `-functions matters. The order in which these functions are called defines the static processing order of the callbacks when the spin-function of the executor is running.
+
+A key feature of the rclc Executor is that the order of these `rclc-executor-add-*`-functions matters. The order in which these functions are called defines the static processing order of the callbacks when the spin-function of the executor is running.
 
 In this example, the timer was added to the executor before the subscription. Therefore, if the timer is ready and also a new message for the subscription is available, then the timer is executed first and after it the subscription. Such a behavior cannot be defined currently with the rclcpp Executor and is useful to implement a deterministic execution semantics.
 
 Finally, you can run the executor with `rclc_executor_spin()`:
+
 ```C
   rclc_executor_spin(&executor);
 ```
+
 This function runs forever without coming back. In this example, however, we want to publish the message only ten times. Therefore we are using the spin-method `rclc_executor_spin_some`, which spins only once and returns. The wait timeout for checking for new messages at the DDS-queue or waiting timers to get ready is configured to be one second.
+
 ```C
 for (unsigned int i = 0; i < 10; i++) {
   // timeout specified in nanoseconds (here 1s)
@@ -403,7 +426,7 @@ for (unsigned int i = 0; i < 10; i++) {
 
 At the end, you need to free dynamically allocated memory:
 
-```C   
+```C
   // clean up
   rc = rclc_executor_fini(&executor);
   rc += rcl_publisher_fini(&my_pub, &my_node);
@@ -425,6 +448,7 @@ return 0;
 This completes the example. The source code can be found in the package rclc-examples [rclc-examples/example_executor_convenience.c](https://github.com/micro-ROS/rclc/blob/master/rclc_examples/src/example_executor_convenience.c).
 
 #### Example 2: Triggered execution
+
 In robotic applications often multiple sensors are used to improve localization precision. These sensors can have different frequencies, for example, a high frequency IMU sensor and a low frequency laser scanner. One way is to trigger execution upon arrival of a laser scan and only then evaluate the most recent data from the aggregated IMU data.
 
 This example demonstrates the additional feature of the rclc executor to trigger the execution of callbacks based on the availability of input data.
@@ -467,16 +491,18 @@ Published: 1
 Callback 1: Hello World! 19 <---
 Callback 2: 1               <---
 ```
+
 This output shows, that the callbacks are executed, only if both message have received new data. In that case, the latest data of high-frequency topic is used.
 
 You learn in this tutorial
-- how to use pre-defined trigger conditions
-- how to write custom-defined trigger conditions
-- how to run multiple executors
-- how to setup quality-of-service parameters for a subscription
 
-We start with the necessary includes for string and int messages, `<std_msgs/msg/string.h>' and
-`std_msgs/msg/int32.h` respectivly. Then the necessary includes follow for the rclc convenience functions `rclc.h`and teh the rclc executor `executor.h`:
+* how to use pre-defined trigger conditions
+* how to write custom-defined trigger conditions
+* how to run multiple executors
+* how to setup quality-of-service parameters for a subscription
+
+We start with the necessary includes for string and int messages, `<std_msgs/msg/string.h>` and `std_msgs/msg/int32.h` respectivly. Then the necessary includes follow for the rclc convenience functions `rclc.h` and the the rclc executor `executor.h`:
+
 ```C
 #include <stdio.h>
 #include <unistd.h>
@@ -486,7 +512,9 @@ We start with the necessary includes for string and int messages, `<std_msgs/msg
 #include <rclc/executor.h>
 #include <rclc/rclc.h>
 ```
+
 Then, global variables for the publishers and subscriptions as well as their messages are defined, which are initialized in the `main()` function and used in the corresponding callbacks:
+
 ```C
 rcl_publisher_t my_pub;
 rcl_publisher_t my_int_pub;
@@ -496,7 +524,9 @@ int pub_int_value;
 std_msgs__msg__Int32 sub_int_msg;
 int pub_string_value;
 ```
+
 For the custom-defined trigger conditions, the type `pub_trigger_object_t` and the type `sub_trigger_object_t` are defined.
+
 ```C
 typedef struct
 {
@@ -510,9 +540,11 @@ typedef struct
   rcl_subscription_t * sub2;
 } sub_trigger_object_t;
 ```
+
 The executor for the publishers shall publish when any of corresponding timers for the publishers is ready. That is the or-logic. You could also use the predefined  `rclc_executor_trigger_any` trigger condition, but this example shows how you can write your own trigger conditions.
 
 In principle, the condition gets a list of handles, the length of this list, and the pre-defined condition type. In this case, we expect `pub_trigger_object_t`. First, the parameter `obj` is cased to this type (`comm_obj`). Then, each element of the handle list is checked for new data (or a timer is ready) by evaluating the field `handles[i].data_available` and its handle pointer is compared to the pointer of the communicatoin object. If at least one timer is ready, then the trigger condition returns true.
+
 ```C
 bool pub_trigger(rclc_executor_handle_t * handles, unsigned int size, void * obj)
 {
@@ -542,6 +574,7 @@ bool pub_trigger(rclc_executor_handle_t * handles, unsigned int size, void * obj
   return (timer1 || timer2);
 }
 ```
+
 The trigger condition for the subscription `sub_trigger`shall implement an AND-logic. That is, only if both subscriptions have received a new message, then the executor shall start processing the callbacks.
 
 The implementation is analogous to `pub_trigger`. The only difference is, that this trigger returns true, if both subscriptions have been found in the handle list. This is implemented in the condition `sub1 && sub2` of the last if-statement.
@@ -576,9 +609,11 @@ bool sub_trigger(rclc_executor_handle_t * handles, unsigned int size, void * obj
   return (sub1 && sub2);
 }
 ```
+
 Like in the Hello-World example, the subscription callbacks just prints out the received message.
 
 The `my_string_subscriber` callback prints out the string of the message `msg->data.data`:
+
 ```C
 void my_string_subscriber_callback(const void * msgin)
 {
@@ -592,6 +627,7 @@ void my_string_subscriber_callback(const void * msgin)
 ```
 
 The integer callback prints out the received integer `msg->data`:
+
 ```C
 void my_int_subscriber_callback(const void * msgin)
 {
@@ -603,12 +639,14 @@ void my_int_subscriber_callback(const void * msgin)
   }
 }
 ```
+
 To publish messages with different frequencies, we setup two timers.
 One timer to publish a string message, the `my_timer_string_callback` and one timer to publish the integer, the `my_timer_int_callback`.
 
 In the `my_timer_string_callback`, the message `pub_msg` is created and filled with the string `Hello World` plus an integer, which is incremented by one, each time the timer callback is called. The the message is published with `rcl_publish()`
 
 The macro `UNUSED` is a workaround for the linter warning, that the second parameter `last_call_time` is not used.
+
 ```C
 #define UNUSED(x) (void)x;
 
@@ -639,7 +677,9 @@ void my_timer_string_callback(rcl_timer_t * timer, int64_t last_call_time)
   }
 }
 ```
+
 Likewise, the `my_timer_int_callback` increments the integer value `pub_int_value` in every call and assigns it to the message field `pub_int_msg.data`. Then the message is published with `rcl_publish()`
+
 ```C
 void my_timer_int_callback(rcl_timer_t * timer, int64_t last_call_time)
 {
@@ -678,6 +718,7 @@ int main(int argc, const char * argv[])
 ```
 
 First rcl is initialized with the `rclc_support_init` using the default `allocator`. The rclc-support objects are saved in `support`. Next, a node `my_node` with the name `node_0` and namespace `executor_examples` is created with:
+
 ```C
 // create rcl_node
   rcl_node_t my_node = rcl_get_zero_initialized_node();
@@ -689,33 +730,36 @@ First rcl is initialized with the `rclc_support_init` using the default `allocat
 ```
 
 A publisher `my_string_pub`, which publishes a string message and its corresponding timer `my_string_timer` with a 100ms period is created like this:
+
 ```C
 // create a publisher 1
-  // - topic name: 'topic_0'
-  // - message type: std_msg::msg::String
-  const char * topic_name = "topic_0";
-  const rosidl_message_type_support_t * my_type_support = ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, String);
+// - topic name: 'topic_0'
+// - message type: std_msg::msg::String
+const char * topic_name = "topic_0";
+const rosidl_message_type_support_t * my_type_support = ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, String);
 
-  rc = rclc_publisher_init_default(&my_string_pub, &my_node, my_type_support, topic_name);
-  if (RCL_RET_OK != rc) {
-    printf("Error in rclc_publisher_init_default %s.\n", topic_name);
-    return -1;
-  }
+rc = rclc_publisher_init_default(&my_string_pub, &my_node, my_type_support, topic_name);
+if (RCL_RET_OK != rc) {
+  printf("Error in rclc_publisher_init_default %s.\n", topic_name);
+  return -1;
+}
 
-  // create timer 1
-  // - publishes 'my_string_pub' every 'timer_timeout' ms
-  rcl_timer_t my_string_timer = rcl_get_zero_initialized_timer();
-  const unsigned int timer_timeout = 100;
-  rc = rclc_timer_init_default(&my_string_timer, &support, RCL_MS_TO_NS(timer_timeout), my_timer_string_callback);
-  if (rc != RCL_RET_OK) {
-    printf("Error in rclc_timer_init_default.\n");
-    return -1;
-  } else {
-    printf("Created timer 'my_string_timer' with timeout %d ms.\n", timer_timeout);
-  }
-  ```
+// create timer 1
+// - publishes 'my_string_pub' every 'timer_timeout' ms
+rcl_timer_t my_string_timer = rcl_get_zero_initialized_timer();
+const unsigned int timer_timeout = 100;
+rc = rclc_timer_init_default(&my_string_timer, &support, RCL_MS_TO_NS(timer_timeout), my_timer_string_callback);
+if (rc != RCL_RET_OK) {
+  printf("Error in rclc_timer_init_default.\n");
+  return -1;
+} else {
+  printf("Created timer 'my_string_timer' with timeout %d ms.\n", timer_timeout);
+}
+```
+
 Note that the previously defined `my_timer_string_callback` is connected to this timer.
-Likewise, a second publisher `my_int_pub, which publishes an int message and its corresponding timer `my_int_timer` with 1000ms period, is created like this:
+Likewise, a second publisher `my_int_pub, which publishes an int message and its corresponding timer` my_int_timer` with 1000ms period, is created like this:
+
 ```C
 // create publisher 2
   // - topic name: 'topic_1'
@@ -741,6 +785,7 @@ Likewise, a second publisher `my_int_pub, which publishes an int message and its
     printf("Created timer with timeout %d ms.\n", timer_int_timeout);
   }
 ```
+
 Note that the `my_timer_int_callback` is connected to the `my_int_timer`. The data variables used for the publisher messages in the timer callbacks need to be initialized first:
 
 ```C
@@ -748,7 +793,9 @@ std_msgs__msg__Int32__init(&int_pub_msg);
 int_pub_value = 0;
 string_pub_value = 0;
 ```
+
 The first subscription `my_string_sub` is created with the function `rcl_subscription_init` because we change the quality-of-service parameter to 'last-is-best'. That is, a new message will overwrite the older message if it has not been processed by the subscription. Also the message `string_sub_msg` needs to be initialized.
+
 ```C
 // create subscription 1
   rcl_subscription_t my_string_sub = rcl_get_zero_initialized_subscription();
@@ -783,12 +830,14 @@ The second subscription `my_int_sub` is created with the rclc convenience functi
 ```
 
 In this example, we are using two executors, one to schedule the publishers, and one to schedule the subscriptions:
+
 ```C
 rclc_executor_t executor_pub;
 rclc_executor_t executor_sub;
 ```
 
 The executor `executor_pub` is first created with  `rclc_executor_get_zero_initialized_executor()` and has two handles (aka 2 timers).
+
 ```C
 // Executor for publishing messages
   unsigned int num_handles_pub = 2;
@@ -820,13 +869,16 @@ if (rc != RCL_RET_OK) {
   printf("Error in rclc_executor_add_timer 'my_int_timer'.\n");
 }
 ```
+
 Also the second publisher has two handles, the two subscriptions:
+
 ```C
 unsigned int num_handles_sub = 2;
 printf("Executor_sub: number of DDS handles: %u\n", num_handles_sub);
 executor_sub = rclc_executor_get_zero_initialized_executor();
 rclc_executor_init(&executor_sub, &support.context, num_handles_sub, &allocator);
 ```
+
 Which are added with the function `rclc_executor_add_subscription`:
 
 ```C
@@ -851,11 +903,14 @@ if (rc != RCL_RET_OK) {
 
 The trigger condition of the executor, which publishes messages, shall execute when any timer is ready. This can be configured with the function `rclc_executor_set_trigger` and the parameter `rclc_executor_trigger_any`.
 While the executor for the subscriptions shall only execute if both messages have arrived. Therefore the trigger parameter `rclc_executor_trigger_any` can be used:
+
 ```C
 rc = rclc_executor_set_trigger(&executor_pub, rclc_executor_trigger_any, NULL);
 rc = rclc_executor_set_trigger(&executor_sub, rclc_executor_trigger_all, NULL);
 ```
+
 Finally, the executors spin-some functions can be started. The sleep-time between the executors is intended for communication time for DDS.
+
 ```C
 for (unsigned int i = 0; i < 100; i++) {
   // timeout specified in ns                 (here: 1s)
@@ -864,7 +919,9 @@ for (unsigned int i = 0; i < 100; i++) {
   rclc_executor_spin_some(&executor_sub, 1000 * (1000 * 1000));
 }
 ```
+
 This example is concluded with the clean-up code:
+
 ```C
 // clean up
 rc = rclc_executor_fini(&executor_pub);
@@ -890,11 +947,10 @@ return 0;
 }
 ```
 
-
-
 In case the default trigger conditions are not sufficient, then the user can define custom logic conditions.
 The source code of the custom-programmed trigger condition has already been presented.
 The following code will setup the executor accordingly:
+
 ```C
  pub_trigger_object_t comm_obj_pub;
  comm_obj_pub.timer1 = &my_string_timer;
@@ -907,6 +963,7 @@ The following code will setup the executor accordingly:
  rc = rclc_executor_set_trigger(&executor_pub, pub_trigger, &comm_obj_pub);
  rc = rclc_executor_set_trigger(&executor_sub, sub_trigger, &comm_obj_sub);
 ```
+
 The custom structs `pub_trigger_object_t` are used to save the pointer of the handles. The timers `my_string_timer` and `my_int_timer` for the publishing executor; and, likewise, the subscriptions `my_string_sub` and `my_int_sub` for the subscribing executor. The configuration is done also with the `rclc_executor_set_trigger` by passing the trigger function and the trigger object, e.g. `pub_trigger` and `comm_obj_pub` for the `executor_pub`, respectivly.
 
 The complete source code of this example can be found in the file [rclc-examples/example_executor_trigger.c](https://github.com/micro-ROS/rclc/rclc_examples/example_executor_trigger.c).

--- a/_docs/tutorials/core/programming_rcl_rclc/index.md
+++ b/_docs/tutorials/core/programming_rcl_rclc/index.md
@@ -215,13 +215,13 @@ if (rc != RCL_RET_OK) {
 
 ## <a name="lifecycle"/>Lifecycle
 
-The rclc lifecycle package provides convenience functions in C to bundle an rclc node with the ROS 2 Node Lifecycle state machine, similar to the [rclcpp Lifecycle Node](https://github.com/ros2/rclcpp/blob/master/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp) for C++.
+The rclc lifecycle package provides convenience functions in C to bundle an rcl node with the ROS 2 Node Lifecycle state machine, similar to the [rclcpp Lifecycle Node](https://github.com/ros2/rclcpp/blob/master/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp) for C++.
 
 This tutorial show-cases how to set up an rclc lifecycle node, transition through its lifecycle states, and assign callbacks to lifecycle transitions.
 
 ### Initialization
 
-Creation of a lifecycle node as a bundle of an rcl node and the rcl Node Lifecycle state machine.
+Creation of a lifecycle node as a bundle of an rcl node and the rcl lifecycle state machine.
 
 ```C
 #include "rclc_lifecycle/rclc_lifecycle.h"
@@ -233,19 +233,19 @@ rcl_ret_t rc;
 // create rcl node
 rc = rclc_support_init(&support, argc, argv, &allocator);
 rcl_node_t my_node = rcl_get_zero_initialized_node();
-rc = rclc_node_init_default(&my_node, "lifecycle_node", "rclc", &support);
+rc = rclc_node_init_default(&my_node, "my_lifecycle_node", "rclc", &support);
 
 // rcl state machine
-rcl_lifecycle_state_machine_t state_machine_ =
+rcl_lifecycle_state_machine_t state_machine =
   rcl_lifecycle_get_zero_initialized_state_machine();
 ...
 
 // create the lifecycle node
-rclc_lifecycle_node_t lifecycle_node;
+rclc_lifecycle_node_t my_lifecycle_node;
 rcl_ret_t rc = rclc_make_node_a_lifecycle_node(
-  &lifecycle_node,
+  &my_lifecycle_node,
   &my_node,
-  &state_machine_,
+  &state_machine,
   &allocator);
 ```
 
@@ -254,13 +254,13 @@ Optionally create hooks for lifecycle state changes.
 ```C
 // declare callback
 rcl_ret_t my_on_configure() {
-  printf("  >>> lifecycle_node: on_configure() callback called.\n");
+  printf("  >>> my_lifecycle_node: on_configure() callback called.\n");
   return RCL_RET_OK;
 }
 ...
 
 // register callbacks
-rclc_lifecycle_register_on_configure(&lifecycle_node, &my_on_configure);
+rclc_lifecycle_register_on_configure(&my_lifecycle_node, &my_on_configure);
 ```
 
 ### Running
@@ -270,11 +270,11 @@ Change states of the lifecycle node, e.g.
 ```C
 bool publish_transition = true;
 rc += rclc_lifecycle_change_state(
-  &lifecycle_node,
+  &my_lifecycle_node,
   lifecycle_msgs__msg__Transition__TRANSITION_CONFIGURE,
   publish_transition);
 rc += rclc_lifecycle_change_state(
-  &lifecycle_node,
+  &my_lifecycle_node,
   lifecycle_msgs__msg__Transition__TRANSITION_ACTIVATE,
   publish_transition);
 ...
@@ -287,14 +287,14 @@ Except for error processing transitions, transitions are usually triggered from 
 To clean everything up, simply do
 
 ```C
-rc += rcl_lifecycle_node_fini(&lifecycle_node, &allocator);
+rc += rcl_lifecycle_node_fini(&my_lifecycle_node, &allocator);
 ```
 
 ### Example and Limitations
 
-An example, how to use the RCLC Lifecycle Node is given in the file `lifecycle_node.c` in the [rclc_examples](https://github.com/micro-ROS/rclc/tree/master/rclc_examples) package.
+An example of the rclc Lifecycle Node is given in the file `lifecycle_node.c` in the [rclc_examples](https://github.com/micro-ROS/rclc/tree/master/rclc_examples) package.
 
-The state machine publishes state changes, however, lifecycle services are not yet exposed via ROS 2 services (tbd).
+The state machine publishes state changes, however, lifecycle services are not yet exposed via ROS 2 services ([micro-ROS/rclc#40](https://github.com/micro-ROS/rclc/issues/40)).
 
 ## <a name="rclc_executor"/>rclc Executor
 


### PR DESCRIPTION
Shows how to set up an rclc lifecycle node, transition through its lifecycle states, and assign callbacks to lifecycle transitions.

Fixes issue #179 as part of #143 .