### PR TITLE
Note on including custom msg pkg in host ws

### DIFF
--- a/_docs/tutorials/core/create_new_type/index.md
+++ b/_docs/tutorials/core/create_new_type/index.md
@@ -136,3 +136,5 @@ msg.point32_test.z = 3.12;
 
 ...
 ```
+
+Note that in order for the micro_ros_agent to register these new types, the package with the custom types you've created above, should also be cloned to the host workspace, e.g. `~/uros_ws/src`, and compiled there as well before running the agent.


### PR DESCRIPTION
It's worth stating that the custom types package needs to exist in the mcu firmware directory as well as the host ws. Using version control is obviously recommended here. Is there a way to better manage this locally without version control and without manually copying changes between the two workspaces?