### PR TITLE
Updated to kramdown 2.3.0 due to security alert.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
     
     - name: Bundle install
       run: |
+        bundle update github-pages
         bundle config path vendor/bundle
         bundle install
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
       jekyll-theme-time-machine (= 0.1.1)
       jekyll-titles-from-headings (= 0.5.3)
       jemoji (= 0.11.1)
-      kramdown (= 1.17.0)
+      kramdown (= 2.3.0)
       liquid (= 4.0.3)
       mercenary (~> 0.3)
       minima (= 2.5.1)


### PR DESCRIPTION
See https://github.com/micro-ROS/micro-ROS.github.io/network/alert/Gemfile.lock/kramdown/open for details.