### PR TITLE
Feature/add rtos page overview

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -2,6 +2,7 @@
   docs:
    - overview/features
    - overview/hardware
+   - overview/rtos
    - overview/transports
    - overview/comparison
    - overview/ROS_2_feature_comparison

--- a/_docs/overview/rtos/index.md
+++ b/_docs/overview/rtos/index.md
@@ -5,7 +5,7 @@ permalink: /docs/overview/rtos/
 
 <style>
 .rtoscontainer {
-  height: 300px;
+  height: auto;
   display: flex;
   flex-direction: row;
   justify-content: flex-start;

--- a/_docs/overview/rtos/index.md
+++ b/_docs/overview/rtos/index.md
@@ -32,15 +32,17 @@ micro-ROS aims to **bring ROS 2 to microcontrollers** to allow having first-clas
 
 The standard approach to micro-ROS assumes a Real-Time Operating System underneath.
 
-Even though recent developments aim at loosening this requirement, with the integration into Arduino IDE being a first step towards true micro-ROS bare-metal support, the RTOS-based support remains the main entrypoint to micro-ROS.
+Even though recent developments aim at loosening this requirement, with the integration into Arduino IDE as an important step towards true micro-ROS bare-metal support, the RTOS-based support remains the main entrypoint to micro-ROS.
 
-micro-ROS is supported by the RTOSes FreeRTOS, Zephyr, NuttX, in addition to Linux and Windows. The features common to all supported RTOSes are a POSIX compliant API to some degree, extremely low to low footprint, and availability of different scheduling algorithms to ensure determinism in micro-ROS apps behavior.
+To date, micro-ROS is supported by the RTOSes FreeRTOS, Zephyr, NuttX, in addition to Linux and Windows. 
+All three RTOSes are downloaded natively with the [micro-ROS build system](https://github.com/micro-ROS/micro_ros_setup), and can be chosen when creating
+a new firmware workspace.
+Dedicated tutorials for running your first micro-ROS application on each of these Operating Systems can be found [here](https://micro-ros.github.io/docs/tutorials/core/first_application_rtos/).
+The features common to all supported RTOSes are an API compliant with POSIX to some degree, extremely low to low footprint, and availability of different scheduling algorithms to ensure determinism in micro-ROS apps behavior.
 Find more details about each of the supported RTOSes below, and a more comprehensive explaination on "Why an RTOS?" in the Concepts section, as this page is meant to provide a schematic overview on the matter.
 
 
 ## Real-Time Operating Systems officially supported by the project
-
-The micro-ROS Tier 2 boards are officially supported for one or more RTOSes and transports.
 
 <div class="rtoscontainer">
   <div class="rtositem_description">
@@ -48,15 +50,17 @@ The micro-ROS Tier 2 boards are officially supported for one or more RTOSes and 
     <div>
         <b>Key features:</b>
         <ul>
-            <li>Extremely small footprint</li>
-            <li>RAM: 520 kB</li>
-            <li>Flash: 4 MB</li>
-            <li>Peripherals: Ethernet MAC, Wi-Fi 802.11 b/g/n, Bluetooth v4.2 BR/EDR, BLE, SPI, I2C, I2S, UART, SDIO, CAN, GPIO, ADC/DAC, PWM  </li>
+            <li>Extremely small footprint.</li>
+            <li>POSIX extension available.</li>
+            <li>Memory management tools</li>
+            <li>Standard and idle tasks available with assignable priorities.</li>
+            <li>Transport resources: TCP/IP and lwIP.</li>
         </ul>  
         <b>Resources:</b>
         <ul>
-            <li><a href="https://www.freertos.org/blog.html">Official website</a></li>
+            <li><a href="https://www.freertos.org/blog.html">Official FreeRTOS website</a></li>
             <li><a href="https://www.freertos.org/2020/09/micro-ros-on-freertos.html">micro-ROS on FreeRTOS</a></li>
+            <li><a href="https://micro-ros.github.io/docs/tutorials/core/first_application_rtos/freertos/">First micro-ROS Application on FreeRTOS</a></li>
         </ul>    
     </div>
   </div>
@@ -72,15 +76,20 @@ The micro-ROS Tier 2 boards are officially supported for one or more RTOSes and 
     <div>
         <b>Key features:</b>
         <ul>
-            <li>MCU: ARM Cortex-M4 MK20DX256VLH7</li>
-            <li>RAM: 64 kB</li>
-            <li>Flash: 256 kB</li>
-            <li>Peripherals: USB, SPI, I2C, CAN, I2S... </li>
+            <li>Small footprint.</li>
+            <li>Native POSIX port.</li>
+            <li>Cross Architecture: Huge collection of <a href="https://docs.zephyrproject.org/latest/boards/index.html">supported boards</a>.</li>
+            <li>Extensive suite of Kernel services.</li>
+            <li>Multiple Scheduling Algorithms.</li>
+            <li>Highly configurable/Modular for flexibility.</li>
+            <li>Native Linux, macOS, and Windows Development.</li>
         </ul>  
         <b>Resources:</b>
         <ul>
-            <li><a href="https://www.zephyrproject.org/">Official website</a></li>
+            <li><a href="https://www.zephyrproject.org/">Official Zephyr website</a></li>
             <li><a href="https://www.zephyrproject.org/micro-ros-a-member-of-the-zephyr-project-and-integrated-into-the-zephyr-build-system-as-a-module/">micro-ROS on Zephyr</a></li>
+            <li><a href="https://micro-ros.github.io/docs/tutorials/core/first_application_rtos/zephyr/">First micro-ROS Application on Zephyr</a></li>
+            <li><a href="https://micro-ros.github.io/docs/tutorials/advanced/zephyr_emulator/">First micro-ROS Application on Zephyr Emulator</a></li>
         </ul>
     </div>
   </div>
@@ -94,7 +103,6 @@ The micro-ROS Tier 2 boards are officially supported for one or more RTOSes and 
   <div class="rtositem_description">
     <h3><b>NuttX</b></h3>
     <div>
-        <p>NuttX is a real-time operating system (RTOS) with an emphasis on standards compliance and small footprint. Scalable from 8-bit to 32-bit microcontroller environments, the primary governing standards in NuttX are Posix and ANSI standards. Additional standard APIs from Unix and other common RTOSes (such as VxWorks) are adopted for functionality not available under these standards, or for functionality that is not appropriate for deeply-embedded environments (such as fork()). Apache NuttX is an effort undergoing Incubation at The Apache Software Foundation (ASF), sponsored by the Incubator.</p>
         <b>Key features:</b>
         <ul>
             <li>POSIX compliant interface to a high degree.</li>
@@ -104,9 +112,9 @@ The micro-ROS Tier 2 boards are officially supported for one or more RTOSes and 
         </ul>  
         <b>Resources:</b>
         <ul>
-            <li><a href="https://nuttx.apache.org/">Official website</a></li>
+            <li><a href="https://nuttx.apache.org/">Official NuttX website</a></li>
+            <li><a href="https://micro-ros.github.io/docs/tutorials/core/first_application_rtos/nuttx/">First micro-ROS Application on NuttX</a></li>
         </ul>
-        <b>**Disclaimer: this tutorial is currently unmantained**</b>
     </div>
   </div>
 
@@ -115,10 +123,12 @@ The micro-ROS Tier 2 boards are officially supported for one or more RTOSes and 
   </div>
 </div>
 
-
 ## Bare metal support
 
-The micro-ROS reference boards are the ones officially supported for all RTOSes and with complete support for all available transports.
+Based on the release of micro-ROS as a standalone library + header files and on the support provided to the Arduino IDE, micro-ROS is available as a bare-metal application, too.
+Fin more details in the dedicated [repo](https://github.com/micro-ROS/micro_ros_arduino).
+
+Arduino is an open-source electronics platform based on easy-to-use hardware and software. Arduino boards are able to read inputs and turn it into an output, by sending instructions to the microcontroller on the board. To do so you use the Arduino programming language (based on Wiring), and the Arduino Software (IDE), based on Processing.
 
 <div class="rtoscontainer">
   <div class="rtositem_description">
@@ -126,17 +136,16 @@ The micro-ROS reference boards are the ones officially supported for all RTOSes 
     <div>
         <b>Key features:</b>
         <ul>
-            <li>MCU: STM32F407ZGT6 Cortex-M4F</li>
-            <li>RAM: 196 kB</li>
-            <li>Flash: 1 MB</li>
-            <li>Peripherals:  USB OTG, Ethernet, SD Card slot, SPI, CAN, I2C... </li>
-        </ul>  
-        
+            <li>Inexpensive.</li>
+            <li>Cross-platform.</li>
+            <li>Simple, clear programming environment.</li>
+            <li>Open source and extensible software.</li>
+            <li>Open source and extensible hardware.</li>
+        </ul>
         <b>Resources:</b>
         <ul>
-            <li><a href="https://www.olimex.com/Products/ARM/ST/STM32-E407/open-source-hardware">Official website</a></li>
-            <li><a href="https://github.com/OLIMEX/STM32F4/blob/master/HARDWARE/STM32-E407/STM32-E407_Rev_F.pdf">Schematics</a></li>
-            <li><a href="https://www.olimex.com/Products/ARM/ST/STM32-E407/resources/STM32-E407.pdf">User Manual</a></li>
+            <li><a href="https://www.arduino.cc/">Official Arduino Website</a></li>
+            <li><a href="https://github.com/micro-ROS/micro_ros_arduino">micro_ros_arduino repo</a></li>
         </ul>    
     </div>
   </div>

--- a/_docs/overview/rtos/index.md
+++ b/_docs/overview/rtos/index.md
@@ -1,0 +1,148 @@
+---
+title: Supported RTOSes
+permalink: /docs/overview/rtos/
+---
+
+<style>
+.rtoscontainer {
+  height: 300px;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
+
+.rtositem_image {
+  width: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.rtositem_description {
+  width: 50%;  
+}
+
+.rtositem_image img {
+    max-width: 80%;
+}
+</style>
+
+micro-ROS aims to **bring ROS 2 to microcontrollers** to allow having first-class ROS 2 entities in the embedded world.
+
+The standard approach to micro-ROS assumes a Real-Time Operating System underneath.
+
+Even though recent developments aim at loosening this requirement, with the integration into Arduino IDE being a first step towards true micro-ROS bare-metal support, the RTOS-based support remains the main entrypoint to micro-ROS.
+
+micro-ROS is supported by the RTOSes FreeRTOS, Zephyr, NuttX, in addition to Linux and Windows. The features common to all supported RTOSes are a POSIX compliant API to some degree, extremely low to low footprint, and availability of different scheduling algorithms to ensure determinism in micro-ROS apps behavior.
+Find more details about each of the supported RTOSes below, and a more comprehensive explaination on "Why an RTOS?" in the Concepts section, as this page is meant to provide a schematic overview on the matter.
+
+
+## Real-Time Operating Systems officially supported by the project
+
+The micro-ROS Tier 2 boards are officially supported for one or more RTOSes and transports.
+
+<div class="rtoscontainer">
+  <div class="rtositem_description">
+    <h3><b>FreeRTOS</b></h3>
+    <div>
+        <b>Key features:</b>
+        <ul>
+            <li>Extremely small footprint</li>
+            <li>RAM: 520 kB</li>
+            <li>Flash: 4 MB</li>
+            <li>Peripherals: Ethernet MAC, Wi-Fi 802.11 b/g/n, Bluetooth v4.2 BR/EDR, BLE, SPI, I2C, I2S, UART, SDIO, CAN, GPIO, ADC/DAC, PWM  </li>
+        </ul>  
+        <b>Resources:</b>
+        <ul>
+            <li><a href="https://www.freertos.org/blog.html">Official website</a></li>
+            <li><a href="https://www.freertos.org/2020/09/micro-ros-on-freertos.html">micro-ROS on FreeRTOS</a></li>
+        </ul>    
+    </div>
+  </div>
+
+  <div class="rtositem_image">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/4/4e/Logo_freeRTOS.png">
+  </div>
+</div>
+
+<div class="rtoscontainer">
+  <div class="rtositem_description">
+    <h3><b>Zephyr</b></h3>
+    <div>
+        <b>Key features:</b>
+        <ul>
+            <li>MCU: ARM Cortex-M4 MK20DX256VLH7</li>
+            <li>RAM: 64 kB</li>
+            <li>Flash: 256 kB</li>
+            <li>Peripherals: USB, SPI, I2C, CAN, I2S... </li>
+        </ul>  
+        <b>Resources:</b>
+        <ul>
+            <li><a href="https://www.zephyrproject.org/">Official website</a></li>
+            <li><a href="https://www.zephyrproject.org/micro-ros-a-member-of-the-zephyr-project-and-integrated-into-the-zephyr-build-system-as-a-module/">micro-ROS on Zephyr</a></li>
+        </ul>
+    </div>
+  </div>
+
+  <div class="rtositem_image">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/2/2d/Zephyr-logo.png">
+  </div>
+</div>
+
+<div class="rtoscontainer">
+  <div class="rtositem_description">
+    <h3><b>NuttX</b></h3>
+    <div>
+        <p>NuttX is a real-time operating system (RTOS) with an emphasis on standards compliance and small footprint. Scalable from 8-bit to 32-bit microcontroller environments, the primary governing standards in NuttX are Posix and ANSI standards. Additional standard APIs from Unix and other common RTOSes (such as VxWorks) are adopted for functionality not available under these standards, or for functionality that is not appropriate for deeply-embedded environments (such as fork()). Apache NuttX is an effort undergoing Incubation at The Apache Software Foundation (ASF), sponsored by the Incubator.</p>
+        <b>Key features:</b>
+        <ul>
+            <li>POSIX compliant interface to a high degree.</li>
+            <li>Rich Feature OS Set</li>
+            <li>Highly scalable</li>
+            <li>Real-Time behavior: fully pre-emptible; fixed priority, round-robin, and “sporadic” scheduling.</li>
+        </ul>  
+        <b>Resources:</b>
+        <ul>
+            <li><a href="https://nuttx.apache.org/">Official website</a></li>
+        </ul>
+        <b>**Disclaimer: this tutorial is currently unmantained**</b>
+    </div>
+  </div>
+
+  <div class="rtositem_image">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/b/b0/NuttX_logo.png">
+  </div>
+</div>
+
+
+## Bare metal support
+
+The micro-ROS reference boards are the ones officially supported for all RTOSes and with complete support for all available transports.
+
+<div class="rtoscontainer">
+  <div class="rtositem_description">
+    <h3><b>Arduino bare-metal support</b></h3>
+    <div>
+        <b>Key features:</b>
+        <ul>
+            <li>MCU: STM32F407ZGT6 Cortex-M4F</li>
+            <li>RAM: 196 kB</li>
+            <li>Flash: 1 MB</li>
+            <li>Peripherals:  USB OTG, Ethernet, SD Card slot, SPI, CAN, I2C... </li>
+        </ul>  
+        
+        <b>Resources:</b>
+        <ul>
+            <li><a href="https://www.olimex.com/Products/ARM/ST/STM32-E407/open-source-hardware">Official website</a></li>
+            <li><a href="https://github.com/OLIMEX/STM32F4/blob/master/HARDWARE/STM32-E407/STM32-E407_Rev_F.pdf">Schematics</a></li>
+            <li><a href="https://www.olimex.com/Products/ARM/ST/STM32-E407/resources/STM32-E407.pdf">User Manual</a></li>
+        </ul>    
+    </div>
+  </div>
+
+  <div class="rtositem_image">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Arduino_Logo.svg/720px-Arduino_Logo.svg.png">
+  </div>
+</div>
+

--- a/_docs/overview/rtos/index.md
+++ b/_docs/overview/rtos/index.md
@@ -24,7 +24,7 @@ permalink: /docs/overview/rtos/
 }
 
 .rtositem_image img {
-    max-width: 80%;
+    max-width: 70%;
 }
 </style>
 
@@ -44,17 +44,19 @@ Find more details about each of the supported RTOSes below, and a more comprehen
 
 ## Real-Time Operating Systems officially supported by the project
 
+In this section, we review the main features of the three RTOSes supported officially by the project, and link to useful documentation.
+
 <div class="rtoscontainer">
   <div class="rtositem_description">
     <h3><b>FreeRTOS</b></h3>
     <div>
         <b>Key features:</b>
         <ul>
-            <li>Extremely small footprint.</li>
-            <li>POSIX extension available.</li>
+            <li>Extremely small footprint</li>
+            <li>POSIX extension available</li>
             <li>Memory management tools</li>
-            <li>Standard and idle tasks available with assignable priorities.</li>
-            <li>Transport resources: TCP/IP and lwIP.</li>
+            <li>Standard and idle tasks available with assignable priorities</li>
+            <li>Transport resources: TCP/IP and lwIP</li>
         </ul>  
         <b>Resources:</b>
         <ul>
@@ -76,13 +78,13 @@ Find more details about each of the supported RTOSes below, and a more comprehen
     <div>
         <b>Key features:</b>
         <ul>
-            <li>Small footprint.</li>
-            <li>Native POSIX port.</li>
-            <li>Cross Architecture: Huge collection of <a href="https://docs.zephyrproject.org/latest/boards/index.html">supported boards</a>.</li>
-            <li>Extensive suite of Kernel services.</li>
-            <li>Multiple Scheduling Algorithms.</li>
-            <li>Highly configurable/Modular for flexibility.</li>
-            <li>Native Linux, macOS, and Windows Development.</li>
+            <li>Small footprint</li>
+            <li>Native POSIX port</li>
+            <li>Cross Architecture: Huge collection of <a href="https://docs.zephyrproject.org/latest/boards/index.html">supported boards</a></li>
+            <li>Extensive suite of Kernel services</li>
+            <li>Multiple Scheduling Algorithms</li>
+            <li>Highly configurable/Modular for flexibility</li>
+            <li>Native Linux, macOS, and Windows Development</li>
         </ul>  
         <b>Resources:</b>
         <ul>
@@ -105,10 +107,10 @@ Find more details about each of the supported RTOSes below, and a more comprehen
     <div>
         <b>Key features:</b>
         <ul>
-            <li>POSIX compliant interface to a high degree.</li>
+            <li>POSIX compliant interface to a high degree</li>
             <li>Rich Feature OS Set</li>
             <li>Highly scalable</li>
-            <li>Real-Time behavior: fully pre-emptible; fixed priority, round-robin, and “sporadic” scheduling.</li>
+            <li>Real-Time behavior: fully pre-emptible; fixed priority, round-robin, and “sporadic” scheduling</li>
         </ul>  
         <b>Resources:</b>
         <ul>
@@ -125,10 +127,10 @@ Find more details about each of the supported RTOSes below, and a more comprehen
 
 ## Bare metal support
 
-Based on the release of micro-ROS as a standalone library + header files and on the support provided to the Arduino IDE, micro-ROS is available as a bare-metal application, too.
+Based on the release of micro-ROS as a standalone library + header files, and on the support provided to the Arduino IDE, micro-ROS is available as a bare-metal application, too.
 Fin more details in the dedicated [repo](https://github.com/micro-ROS/micro_ros_arduino).
 
-Arduino is an open-source electronics platform based on easy-to-use hardware and software. Arduino boards are able to read inputs and turn it into an output, by sending instructions to the microcontroller on the board. To do so you use the Arduino programming language (based on Wiring), and the Arduino Software (IDE), based on Processing.
+The open-source Arduino Software (IDE) is a library making it easy to program any Arduino board.
 
 <div class="rtoscontainer">
   <div class="rtositem_description">
@@ -136,11 +138,11 @@ Arduino is an open-source electronics platform based on easy-to-use hardware and
     <div>
         <b>Key features:</b>
         <ul>
-            <li>Inexpensive.</li>
-            <li>Cross-platform.</li>
-            <li>Simple, clear programming environment.</li>
-            <li>Open source and extensible software.</li>
-            <li>Open source and extensible hardware.</li>
+            <li>Inexpensive</li>
+            <li>Cross-platform</li>
+            <li>Simple, clear programming environment</li>
+            <li>Open source and extensible software</li>
+            <li>Open source and extensible hardware</li>
         </ul>
         <b>Resources:</b>
         <ul>
@@ -151,7 +153,7 @@ Arduino is an open-source electronics platform based on easy-to-use hardware and
   </div>
 
   <div class="rtositem_image">
-    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Arduino_Logo.svg/720px-Arduino_Logo.svg.png">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Arduino_Logo.svg/720px-Arduino_Logo.svg.png" width="500">
   </div>
 </div>
 


### PR DESCRIPTION
Add an overview page on the supported RTOSes, in the same style as the new HW page.