### PR TITLE
Clarify tutorial creates a new msg type

### DIFF
--- a/_docs/tutorials/core/create_new_type/index.md
+++ b/_docs/tutorials/core/create_new_type/index.md
@@ -1,5 +1,5 @@
 ---
-title: How to create a new micro-ROS type
+title: How to create a new micro-ROS message type
 permalink: /docs/tutorials/core/create_new_type/
 ---
 


### PR DESCRIPTION
I realise there are more things to change to fully implement this change, but I wanted to first ask whether the suggestion makes sense.

"create a micro-ROS type" sounded like support for a new board was being added, or something else which was "a micro-ROS type".

From the tutorial it appears a custom message is created and a package to host it, which is then added to the micro-ROS build and eventually built.

Is this correct?
