### PR TITLE
Add RT-Thread Support

### DIFF
--- a/_docs/overview/rtos/index.md
+++ b/_docs/overview/rtos/index.md
@@ -152,6 +152,43 @@ NuttX emphasizes its compliance with standards - including POSIX - and small foo
   </div>
 </div>
 
+### **RT-Thread**
+
+RT-Thread is an open source, neutral, and community-based real-time operating system (RTOS). RT-Thread has Standard version and Nano version. For resource-constrained microcontroller (MCU) systems, the NANO kernel version that requires only 3 KB Flash and 1.2 KB RAM memory resources can be tailored with easy-to-use tools; And for resource-rich IoT devices, RT-Thread can use the online software package management tool, together with system configuration tools, to achieve intuitive and rapid modular cutting, seamlessly import rich software packages, thus achieving complex functions like Android's graphical interface and touch sliding effects, smart voice interaction effects, and so on.
+
+<div class="rtoscontainer">
+  <div class="rtositem_description">
+    <div>
+        <b>Key features:</b>
+        <ul>
+            <li>Designed for resource-constrained devices, the minimum kernel requires only 1.2KB of RAM and 3 KB of Flash.</li>
+            <li>Has rich components and a prosperous and fast growing <a href="https://packages.rt-thread.org/en/">package ecosystem</a>.</li>
+            <li>Elegant code style, easy to use, read and master.</li>
+            <li>High Scalability. RT-Thread has high-quality scalable software architecture, loose coupling, modularity, is easy to tailor and expand.</li>
+            <li>Supports high-performance applications.</li>
+            <li>Supports cross-platform and a wide range of <a href="https://www.rt-thread.io/board.html">chips</a>.</lili>
+        </ul>
+        <b>RT-Thread resources:</b>
+        <ul>
+            <li><a href="https://www.rt-thread.io/">Official RT-Thread website</a></li>
+            <li><a href="https://github.com/rt-thread/rt-thread">Download</a></li>
+            <li><a href="https://www.rt-thread.io/document/site/">Documentation</a></li>
+            <li><a href="https://www.rt-thread.io/studio.html">RT-Thread Studio</a></li>
+        </ul>
+        <b>RT-Thread &amp; micro-ROS:</b>
+        <ul>
+            <li><a href="https://github.com/wuhanstudio/micro_ros">First micro-ROS Application on RT-Thread</a></li>
+        </ul>
+    </div>
+  </div>
+
+
+  <div class="rtositem_image">
+    <img src="https://www.rt-thread.io/images/logo_down.png">
+  </div>
+</div>
+
+
 ## Bare metal support
 
 Based on the release of micro-ROS as a standalone library with header files, and on the support provided to the Arduino IDE, micro-ROS is available as a bare-metal application, too.


### PR DESCRIPTION
Hi,

Recently micro_ros has been ported to [RT-Thread](https://github.com/rt-thread/rt-thread), which is an RTOS that supports [150+ boards](https://www.rt-thread.io/board.html). With native POSIX support, it requires little effort to port [various applications](https://packages.rt-thread.org/en/) onto  RT-Thread. 

The micro_ros package is now available in [RT-Thread Software Package](https://packages.rt-thread.org/en/). Would you like to incoorperate RT-Thread as one of the [Supported RTOSes](https://micro.ros.org/docs/overview/rtos/)?

Looking forward to hearing from you.
Han

https://user-images.githubusercontent.com/15157070/131862283-a951bd37-c47d-4814-a76e-e5e2ddc9967c.mp4
