### PR TITLE
Add dependencies to rosidl in CMakeLists.txt

### DIFF
--- a/_docs/tutorials/advanced/create_new_type/index.md
+++ b/_docs/tutorials/advanced/create_new_type/index.md
@@ -94,6 +94,7 @@ find_package(geometry_msgs REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/MyCustomMessage.msg"
+  DEPENDENCIES geometry_msgs
  )
 ...
 ```


### PR DESCRIPTION
I followed this tutorial and without adding dependencies to rosidl, the error message:
ImportError: /home/dan/work/microros_ws/install/hw_msgs/lib/libhw_msgs__rosidl_generator_c.so: undefined symbol: std_msgs__msg__Header__fini
pops up(in my case because of std_msgs) when publishing with the agent. I had no other errors in the compilation process.

In the official tutorial it's also present:
https://docs.ros.org/en/foxy/Tutorials/Single-Package-Define-And-Use-Interface.html