### PR TITLE
Add notes to ros2_tracing tutorial

### DIFF
--- a/_docs/tutorials/advanced/tracing/index.md
+++ b/_docs/tutorials/advanced/tracing/index.md
@@ -8,6 +8,10 @@ redirect_from:
 
 <img src="https://img.shields.io/badge/Applies_to-all_current_distros-green" style="display:inline"/>
 
+**Note: While `ros2_tracing` has been associated with micro-ROS, `ros2_tracing` does not currently officially support nor target microcontrollers.**
+
+**Note: For a more up-to-date tutorial, please refer to the [`ros2_tracing` tutorial on the ROS 2 Real-Time Working Group documentation](https://real-time-working-group.readthedocs.io/en/latest/Guides/ros2_tracing_trace_and_analyze.html).**
+
 - [Introduction](#introduction)
 - [Setup](#setup)
 - [Simple tracing example](#simple-tracing-example)


### PR DESCRIPTION
The first note is to make it clear that `ros2_tracing` does not target microcontrollers, so this tutorial is not meant to work on microcontrollers. See #224.

The second note links to a newer tutorial with a more realistic/practical setup.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>