### PR TITLE
Correct 'rosdep install' cmd: --from-path -> --from-paths

### DIFF
--- a/_docs/tutorials/core/teensy_with_arduino/index.md
+++ b/_docs/tutorials/core/teensy_with_arduino/index.md
@@ -51,7 +51,7 @@ cd microros_ws
 git clone -b $ROS_DISTRO https://github.com/micro-ROS/micro_ros_setup.git src/micro_ros_setup
 # Update dependencies using rosdep
 sudo apt update && rosdep update
-rosdep install --from-path src --ignore-src -y
+rosdep install --from-paths src --ignore-src -y
 # Install pip
 sudo apt-get install python3-pip
 

--- a/_includes/first_application_common/build_system.md
+++ b/_includes/first_application_common/build_system.md
@@ -24,7 +24,7 @@ git clone -b $ROS_DISTRO https://github.com/micro-ROS/micro_ros_setup.git src/mi
 
 # Update dependencies using rosdep
 sudo apt update && rosdep update
-rosdep install --from-path src --ignore-src -y
+rosdep install --from-paths src --ignore-src -y
 
 # Install pip
 sudo apt-get install python3-pip


### PR DESCRIPTION
As per subject.

There is one more occurrence, but it's in `_docs/tutorials/old/add_microros_config/index.md`, which makes me assume it's not being used/updated any more.
