### PR TITLE
Update foxy to humble

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,16 +2,24 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
-
-# To fully customize the contents of this image, use the following Dockerfile instead:
-# https://github.com/microsoft/vscode-dev-containers/tree/v0.106.0/containers/ubuntu-18.04-git/.devcontainer/Dockerfile
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
-   && apt-get -y install --no-install-recommends build-essential ruby ruby-dev locales zlib1g-dev \
+WORKDIR /workspace
+SHELL ["/bin/bash", "-c"]
+RUN apt-get update && apt-get -y upgrade \
+   && apt-get -y install --reinstall ca-certificates \
+   && update-ca-certificates \
+   && apt-get -y install --no-install-recommends build-essential locales zlib1g-dev curl git \
+   && curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash \
+   && echo 'eval "$(~/.rbenv/bin/rbenv init - bash)"' >> ~/.bashrc \
+   && source ~/.bashrc \
+   # Use latest version 2 of ruby
+   # WARNING: ruby-2.7.7 is nearing its end of life.
+   # It only receives critical security updates, no bug fixes.
+   && rbenv install 2.7.7 \
+   && rbenv global 2.7.7 \
    && gem install bundler \
-   #
    # Clean up
    && apt-get autoremove -y \
    && apt-get clean -y \
@@ -24,7 +32,3 @@ ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 ENV DEBIAN_FRONTEND=dialog
-
-# TEST COMMANDS:
-# bundle install
-# bundle exec jekyll serve --incremental

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.106.0/containers/ubuntu-18.04-git
 {
-	"name": "Ubuntu 18.04 & Git",
+	"name": "Ubuntu 22.04 & Git",
 	"dockerFile": "Dockerfile",
 
 	// Set *default* container specific settings.json values on container create.
@@ -10,7 +10,7 @@
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": []
+	"extensions": [],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/.github/ISSUE_TEMPLATE/general-issue.md
+++ b/.github/ISSUE_TEMPLATE/general-issue.md
@@ -11,8 +11,8 @@ assignees: ''
 
 - Hardware description: <!-- hardware where you are using micro-ROS -->
 - RTOS: <!-- RTOS where you are using micro-ROS -->
-- Installation type: <!-- micro_ros_setup, modules, etc  -->
-- Version or commit hash: <!-- version of micro-ROS used: foxy, galactic, rolling  -->
+- Installation type: <!-- micro_ros_setup, modules, docker, etc  -->
+- Version or commit hash: <!-- version of micro-ROS used: foxy, galactic, humble, rolling  -->
 
 #### Steps to reproduce the issue
 <!-- Detailed instructions on how to reliably reproduce this issue http://sscce.org/-->

--- a/.github/workflows/generate_api_reference.yml
+++ b/.github/workflows/generate_api_reference.yml
@@ -28,7 +28,7 @@ jobs:
             unzip doxybook2-linux-amd64-v1.3.3.zip -d doxybook2
 
             mkdir -p ros2_ws/src; cd ros2_ws
-            git clone -b master https://github.com/eProsima/Micro-CDR src/Micro-CDR
+            git clone -b ros2 https://github.com/eProsima/Micro-CDR src/Micro-CDR
             git clone -b master https://github.com/eProsima/Micro-XRCE-DDS-Client src/Micro-XRCE-DDS-Client
             git clone -b humble https://github.com/micro-ROS/rosidl_typesupport_microxrcedds src/rosidl_typesupport_microxrcedds
             git clone -b humble https://github.com/micro-ROS/rmw-microxrcedds src/rmw-microxrcedds

--- a/.github/workflows/generate_api_reference.yml
+++ b/.github/workflows/generate_api_reference.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   generate_rmw_api_reference:
     runs-on: ubuntu-latest
-    container: ros:foxy
+    container: ros:humble
     steps:
       - uses: actions/checkout@v3
       - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -28,10 +28,10 @@ jobs:
             unzip doxybook2-linux-amd64-v1.3.3.zip -d doxybook2
 
             mkdir -p ros2_ws/src; cd ros2_ws
-            git clone -b foxy https://github.com/eProsima/Micro-CDR src/Micro-CDR
-            git clone -b foxy https://github.com/eProsima/Micro-XRCE-DDS-Client src/Micro-XRCE-DDS-Client
-            git clone -b foxy https://github.com/micro-ROS/rosidl_typesupport_microxrcedds src/rosidl_typesupport_microxrcedds
-            git clone -b foxy https://github.com/micro-ROS/rmw-microxrcedds src/rmw-microxrcedds
+            git clone -b master https://github.com/eProsima/Micro-CDR src/Micro-CDR
+            git clone -b master https://github.com/eProsima/Micro-XRCE-DDS-Client src/Micro-XRCE-DDS-Client
+            git clone -b humble https://github.com/micro-ROS/rosidl_typesupport_microxrcedds src/rosidl_typesupport_microxrcedds
+            git clone -b humble https://github.com/micro-ROS/rmw-microxrcedds src/rmw-microxrcedds
 
             source /opt/ros/$ROS_DISTRO/setup.bash
             colcon build --packages-up-to rmw_microxrcedds --cmake-args -DBUILD_DOCUMENTATION=ON
@@ -50,7 +50,7 @@ jobs:
 
   generate_utils_api_reference:
     runs-on: ubuntu-latest
-    container: ros:foxy
+    container: ros:humble
     steps:
       - uses: actions/checkout@v3
       - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -61,7 +61,7 @@ jobs:
         shell: bash
         run: |
           apt update
-          apt install -y doxygen wget git unzip cmake ros-foxy-osrf-testing-tools-cpp
+          apt install -y doxygen wget git unzip cmake ros-humble-osrf-testing-tools-cpp
 
           pushd /
             wget https://github.com/matusnovak/doxybook2/releases/download/v1.3.3/doxybook2-linux-amd64-v1.3.3.zip

--- a/.github/workflows/generate_api_reference.yml
+++ b/.github/workflows/generate_api_reference.yml
@@ -29,7 +29,7 @@ jobs:
 
             mkdir -p ros2_ws/src; cd ros2_ws
             git clone -b ros2 https://github.com/eProsima/Micro-CDR src/Micro-CDR
-            git clone -b master https://github.com/eProsima/Micro-XRCE-DDS-Client src/Micro-XRCE-DDS-Client
+            git clone -b ros2 https://github.com/eProsima/Micro-XRCE-DDS-Client src/Micro-XRCE-DDS-Client
             git clone -b humble https://github.com/micro-ROS/rosidl_typesupport_microxrcedds src/rosidl_typesupport_microxrcedds
             git clone -b humble https://github.com/micro-ROS/rmw-microxrcedds src/rmw-microxrcedds
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For details on the open source components included in the micro-ros.github.io re
 ## Running locally
 
 ```bash
-git clone --recurse-submodules <your fork of micro-ROS.github.io>
+git clone --recurse-submodules https://github.com/micro-ROS/micro-ROS.github.io
 ```
 
 To test locally, you need a local version of Jekyll, the site-generation

--- a/README.md
+++ b/README.md
@@ -33,23 +33,36 @@ Please note the following third-party elements and content:
 
 For details on the open source components included in the micro-ros.github.io repository, see the file [3rd-party-licenses.txt](3rd-party-licenses.txt).
 
+
 ## Running locally
+
+```bash
+git clone --recurse-submodules <your fork of micro-ROS.github.io>
+```
 
 To test locally, you need a local version of Jekyll, the site-generation
 engine used by GitHub Pages. See [Jekyll Quickstart](https://jekyllrb.com/docs/)
 for installation instructions.
 
-After installing Jekyll, install all dependencies by running
+Or, if using VSCode, feel free to use the attached devcontainer with
+`ms-vscode-remote.remote-containers` extension.
+
+After installing Jekyll or opening the Docker container,
+install all dependencies by running
 ```bash
 bundle install
 ```
 
+For the includes of README.md files on the micro-ROS demos (in the tutorials chapter) from the corresponding repositories, please init and update the corresponding git submodules (i.e. `git submodule update --init --recursive`).
+
 Then, you may launch Jekyll to build and serve the website continuously by
 ```bash
-bundle exec jekyll serve
+bundle exec jekyll serve --incremental
+# ... 
+# Server address: http://127.0.0.1:4000/
 ```
 
-For the includes of README.md files on the micro-ROS demos (in the tutorials chapter) from the corresponding repositories, please init and update the corresponding git submodules (i.e. `git submodule init ; git submodule update`).
+When complete, click the link to vuew the local website.
 
 ## Testing generated site
 
@@ -57,7 +70,7 @@ To test the generated HTML site, you can use `html-proofer` gem.
 This Ruby gem checks and validates the jekyll generated HTML files.
 It checks a broad set of points: internal and external links existence (alerting of possible 404 errors), HTML attributes of the images and so on.
 
-To install it, It has been incorporated in the Gemfile so the previous dependency install command would have already installed it.
+To install it, it has been incorporated in the Gemfile so the previous dependency install command would have already installed it.
 
 You can run `bundle exec jekyll build` followed by `bundle exec htmlproofer ./_site` to build and test the generated site.
 However, note that a comprehensive configuration is required for the htmlproofer.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ bundle exec jekyll serve --incremental
 # Server address: http://127.0.0.1:4000/
 ```
 
-When complete, click the link to vuew the local website.
+When complete, click the link to view the local website.
 
 ## Testing generated site
 

--- a/_includes/first_application_common/build_system.md
+++ b/_includes/first_application_common/build_system.md
@@ -1,21 +1,21 @@
 ## Installing ROS 2 and the micro-ROS build system
 
-First of all, install **ROS 2 Foxy FitzRoy** on your Ubuntu 20.04 LTS computer.
+First of all, install **ROS 2 Humble Hawskbill** on your Ubuntu 22.04 LTS computer.
 To do so from binaries, via Debian packages, follow the instructions detailed
-[here](https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Install-Debians/).
+[here](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html).
 
-***TIP:** Alternatively, you can use a docker container with a fresh ROS 2 Foxy installation. The one that serves
+***TIP:** Alternatively, you can use a docker container with a fresh ROS 2 Humble installation. The one that serves
 the purpose is the container run by the command:*
 
 ```bash
-docker run -it --net=host -v /dev:/dev --privileged ros:foxy
+docker run -it --net=host -v /dev:/dev --privileged ros:humble
 ```
 
 Once you have a ROS 2 installation in the computer, follow these steps to install the micro-ROS build system:
 
 ```bash
 # Source the ROS 2 installation
-source /opt/ros/$ROS_DISTRO/setup.bash
+source /opt/ros/humble/setup.bash
 
 # Create a workspace and download the micro-ROS tools
 mkdir microros_ws


### PR DESCRIPTION
I tried to update the docs to refer to humble. That said, I had some really nasty errors trying to get bundle set up. 

- [x]  What do we do about [thumper](https://github.com/micro-ROS/micro-ROS_thumper_demo) last being updated for foxy? See https://github.com/micro-ROS/micro-ROS_thumper_demo/issues/1
- [x] Does someone else need to run jekyll on this branch for me? -no, I was able to run it fine
